### PR TITLE
feat: add env var `NEXT_PUBLIC_DEVNET_HOST`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 clarity/.turbo/
 clarity/.debug_history
+clarity/.cache/

--- a/front-end/.env.example
+++ b/front-end/.env.example
@@ -1,4 +1,7 @@
 # Network configuration
 NEXT_PUBLIC_STACKS_NETWORK=devnet
 
+# "platform" when running devnet in Hiro platform, "local" when running devnet locally
+NEXT_PUBLIC_DEVNET_HOST=platform
+
 NEXT_PUBLIC_PLATFORM_HIRO_API_KEY=XXXX

--- a/front-end/src/constants/devnet.ts
+++ b/front-end/src/constants/devnet.ts
@@ -3,8 +3,12 @@ import { STACKS_TESTNET, StacksNetwork } from '@stacks/network';
 // platform api domain
 export const PLATFORM_API_DOMAIN = 'https://api.platform.hiro.so';
 
-export const DEVNET_STACKS_BLOCKCHAIN_API_URL = `${PLATFORM_API_DOMAIN}/v1/ext/${process.env.NEXT_PUBLIC_PLATFORM_HIRO_API_KEY}/stacks-blockchain-api`;
-// export const DEVNET_STACKS_BLOCKCHAIN_API_URL = `http://localhost:3999`;
+export const DEVNET_STACKS_BLOCKCHAIN_API_URL_PLATFORM = `${PLATFORM_API_DOMAIN}/v1/ext/${process.env.NEXT_PUBLIC_PLATFORM_HIRO_API_KEY}/stacks-blockchain-api`;
+export const DEVNET_STACKS_BLOCKCHAIN_API_URL_LOCAL = `http://localhost:3999`;
+export const DEVNET_STACKS_BLOCKCHAIN_API_URL =
+  process.env.NEXT_PUBLIC_DEVNET_HOST === 'platform'
+    ? DEVNET_STACKS_BLOCKCHAIN_API_URL_PLATFORM
+    : DEVNET_STACKS_BLOCKCHAIN_API_URL_LOCAL;
 
 export const DEVNET_NETWORK: StacksNetwork = {
   ...STACKS_TESTNET,


### PR DESCRIPTION
This new environment variable allows the user to define whether devnet is running locally (`local`) or on Hiro Platform (`platform`). define whether devnet is local or on Hiro Platform